### PR TITLE
feat: update form op types

### DIFF
--- a/wotpy/protocols/http/server.py
+++ b/wotpy/protocols/http/server.py
@@ -109,19 +109,12 @@ class HTTPServer(BaseProtocolServer):
             self.scheme, hostname.rstrip("/").lstrip("/"), self.port,
             proprty.thing.url_name, proprty.url_name)
 
-        form_read = Form(
+        form_read_write = Form(
             interaction=proprty,
             protocol=self.protocol,
             href=href_read_write,
             content_type=MediaTypes.JSON,
-            op=InteractionVerbs.READ_PROPERTY)
-
-        form_write = Form(
-            interaction=proprty,
-            protocol=self.protocol,
-            href=href_read_write,
-            content_type=MediaTypes.JSON,
-            op=InteractionVerbs.WRITE_PROPERTY)
+            op=[InteractionVerbs.READ_PROPERTY, InteractionVerbs.WRITE_PROPERTY])
 
         href_observe = "{}/subscription".format(href_read_write)
 
@@ -130,9 +123,9 @@ class HTTPServer(BaseProtocolServer):
             protocol=self.protocol,
             href=href_observe,
             content_type=MediaTypes.JSON,
-            op=InteractionVerbs.OBSERVE_PROPERTY)
+            op=[InteractionVerbs.OBSERVE_PROPERTY])
 
-        return [form_read, form_write, form_observe]
+        return [form_read_write, form_observe]
 
     def _build_forms_action(self, action, hostname):
         """Builds and returns the HTTP Form instances for the given Action interaction."""
@@ -146,7 +139,7 @@ class HTTPServer(BaseProtocolServer):
             protocol=self.protocol,
             href=href_invoke,
             content_type=MediaTypes.JSON,
-            op=InteractionVerbs.INVOKE_ACTION)
+            op=[InteractionVerbs.INVOKE_ACTION])
 
         return [form_invoke]
 
@@ -162,7 +155,7 @@ class HTTPServer(BaseProtocolServer):
             protocol=self.protocol,
             href=href_observe,
             content_type=MediaTypes.JSON,
-            op=InteractionVerbs.SUBSCRIBE_EVENT)
+            op=[InteractionVerbs.SUBSCRIBE_EVENT])
 
         return [form_observe]
 

--- a/wotpy/wot/form.py
+++ b/wotpy/wot/form.py
@@ -51,5 +51,5 @@ class Form(object):
             self.protocol,
             self.href,
             self.content_type,
-            self.op
+            tuple(self.op) if isinstance(self.op, list) else self.op
         ))

--- a/wotpy/wot/validation.py
+++ b/wotpy/wot/validation.py
@@ -92,7 +92,15 @@ SCHEMA_FORM = {
             "type": "string",
             "default": "application/json"
         },
-        "op": {"type": "string"},
+        "op": { "oneOf": [
+            {
+                "type": "string"
+            },
+            {
+                "type": "array",
+                "items": {"type": "string"}
+            }
+            ]},
         "subprotocol": {"type": "string"},
         "security": {
             "type": "array",


### PR DESCRIPTION
This PR updates the form `op` types according to the latest TD spec. Namely, the PR turns the `op` field from just a `string` type to a type of `string or an array of strings`. It also combines `writeproperty` and `readproperty` forms into one form.
@agmangas please let me know if I missed anything that also might be affected by the PR.

Closes #12
Signed-off-by: fatadel <fatadel@gmail.com>