### PR TITLE
refactor: change name field in TD to title

### DIFF
--- a/examples/coffee-machine/coffee-machine-client.py
+++ b/examples/coffee-machine/coffee-machine-client.py
@@ -21,7 +21,7 @@ LOGGER.setLevel(logging.INFO)
 
 async def main():
     wot = WoT(servient=Servient())
-    consumed_thing = await wot.consume_from_url('http://127.0.0.1:9090/urn-dev-wot-example-coffee-machine-97e83de1-f5c9-a4a0-23b6-be918d3a22ca')
+    consumed_thing = await wot.consume_from_url('http://127.0.0.1:9090/smart-coffee-machine-97e83de1-f5c9-a4a0-23b6-be918d3a22ca')
 
     LOGGER.info('Consumed Thing: {}'.format(consumed_thing))
 

--- a/wotpy/wot/dictionaries/thing.py
+++ b/wotpy/wot/dictionaries/thing.py
@@ -26,7 +26,7 @@ class ThingFragment(WotBaseDict):
         fields = {
             "id",
             "version",
-            "name",
+            "title",
             "description",
             "support",
             "created",
@@ -48,7 +48,7 @@ class ThingFragment(WotBaseDict):
         ]
 
         fields_str = [
-            "name",
+            "title",
             "description",
             "support",
             "created",
@@ -102,11 +102,11 @@ class ThingFragment(WotBaseDict):
             return
 
     @property
-    def name(self):
-        """The name of the Thing.
-        This property returns the ID if the name is undefined."""
+    def title(self):
+        """The title of the Thing.
+        This property returns the ID if the title is undefined."""
 
-        return self._init.get("name", self.id)
+        return self._init.get("title", self.id)
 
     @property
     def security(self):

--- a/wotpy/wot/thing.py
+++ b/wotpy/wot/thing.py
@@ -23,7 +23,7 @@ class Thing(object):
 
     THING_FRAGMENT_WRITABLE_FIELDS = {
         "version",
-        "name",
+        "title",
         "description",
         "support",
         "created",
@@ -120,10 +120,10 @@ class Thing(object):
         return self.thing_fragment.id
 
     @property
-    def name(self):
-        """Thing name."""
+    def title(self):
+        """Thing title."""
 
-        return self.thing_fragment.name
+        return self.thing_fragment.title
 
     @property
     def uuid(self):
@@ -142,7 +142,7 @@ class Thing(object):
         """Returns the URL-safe name of this Thing.
         The URL name of a Thing is always unique and stable as long as the ID is unique."""
 
-        return slugify("{}-{}".format(self.name, self.uuid))
+        return slugify("{}-{}".format(self.title, self.uuid))
 
     @property
     def properties(self):

--- a/wotpy/wot/validation.py
+++ b/wotpy/wot/validation.py
@@ -214,7 +214,7 @@ SCHEMA_THING = {
             "pattern": REGEX_ANY_URI
         },
         "version": SCHEMA_VERSIONING,
-        "name": {"type": "string"},
+        "title": {"type": "string"},
         "description": {"type": "string"},
         "support": {"type": "string"},
         "created": {"type": "string"},
@@ -249,7 +249,7 @@ SCHEMA_THING = {
     },
     "required": [
         "id",
-        "name",
+        "title",
         "security"
     ]
 }


### PR DESCRIPTION
In an old version of the TD spec, the `title` field was called `name`. This PR makes it up to date by renaming to `title`.

Closes #8
Signed-off-by: fatadel <fatadel@gmail.com>