### PR TITLE
security and securityDefinitions

### DIFF
--- a/tests/td_examples.py
+++ b/tests/td_examples.py
@@ -5,7 +5,10 @@ TD_EXAMPLE = {
     "id": "urn:dev:wot:com:example:servient:lamp",
     "title": "MyLampThing",
     "description": "MyLampThing uses JSON-LD 1.1 serialization",
-    "security": [{"scheme": "nosec"}],
+    "security": ["nosec_sc"],
+    "securityDefinitions": {
+        "nosec_sc": {"scheme": "nosec"}
+    },
     "properties": {
         "status": {
             "description": "Shows the current status of the lamp",

--- a/tests/wot/test_dictionaries.py
+++ b/tests/wot/test_dictionaries.py
@@ -223,12 +223,12 @@ def test_thing_fragment_setters():
 
     assert next(six.itervalues(thing_fragment.properties)).description == prop_fragment.description
 
-    security_updated = [SecuritySchemeDict(scheme=SecuritySchemeType.PSK)]
+    security_defs_updated = {"psk_sc": SecuritySchemeDict(scheme=SecuritySchemeType.PSK)}
 
     # noinspection PyPropertyAccess
-    thing_fragment.security = security_updated
+    thing_fragment.security_definitions = security_defs_updated
 
-    assert thing_fragment.security[0].scheme == security_updated[0].scheme
+    assert thing_fragment.security_definitions["psk_sc"].scheme == security_defs_updated["psk_sc"].scheme
 
     version_updated = VersioningDict(instance=Faker().pystr())
 

--- a/tests/wot/test_wot.py
+++ b/tests/wot/test_wot.py
@@ -132,7 +132,10 @@ def test_consume_from_url(td_example_tornado_app):
 TD_DICT_01 = {
     "id": uuid.uuid4().urn,
     "title": Faker().pystr(),
-    "security": [{"scheme": "psk"}],
+    "security": ["psk_sc"],
+    "securityDefinitions": {
+        "psk_sc": {"scheme": "psk"}
+    },
     "version": {"instance": "1.2.1"},
     "properties": {
         "status": {
@@ -314,7 +317,7 @@ def test_discovery_fragment():
         ({"title": TD_DICT_01.get("title")}, TD_DICT_01),
         ({"version": {"instance": "2.0.0"}}, TD_DICT_02),
         ({"id": TD_DICT_02.get("id")}, TD_DICT_02),
-        ({"security": [{"scheme": "psk"}]}, TD_DICT_01)
+        ({"securityDefinitions": {"psk_sc": {"scheme": "psk"}}}, TD_DICT_01)
     ]
 
     for fragment, td_expected in fragment_td_pairs:

--- a/wotpy/wot/dictionaries/thing.py
+++ b/wotpy/wot/dictionaries/thing.py
@@ -36,7 +36,8 @@ class ThingFragment(WotBaseDict):
             "actions",
             "events",
             "links",
-            "security"
+            "security",
+            "securityDefinitions"
         }
 
         required = {
@@ -59,7 +60,8 @@ class ThingFragment(WotBaseDict):
         fields_dict = [
             "properties",
             "actions",
-            "events"
+            "events",
+            "securityDefinitions"
         ]
 
         fields_list = [
@@ -115,10 +117,20 @@ class ThingFragment(WotBaseDict):
         below the current level, if not overridden at a lower level.
         A default nosec security scheme will be provided if none are defined."""
 
-        if "security" not in self._init:
-            return [SecuritySchemeDict.build({"scheme": SecuritySchemeType.NOSEC})]
+        if "security" not in self._init and "securityDefinitions" not in self._init:
+            return ["nosec_sc"]
 
-        return [SecuritySchemeDict.build(item) for item in self._init.get("security")]
+        return self._init.get("security")
+
+    @property
+    def security_definitions(self):
+        if "security" not in self._init and "securityDefinitions" not in self._init:
+            return {"nosec_sc": SecuritySchemeDict.build({"scheme": SecuritySchemeType.NOSEC})}
+
+        return {
+            key: SecuritySchemeDict.build(val) 
+            for key, val in six.iteritems(self._init.get("securityDefinitions", {}))
+        }
 
     @property
     def properties(self):

--- a/wotpy/wot/validation.py
+++ b/wotpy/wot/validation.py
@@ -252,13 +252,19 @@ SCHEMA_THING = {
         },
         "security": {
             "type": "array",
-            "items": SCHEMA_SECURITY_SCHEME
+            "items": {"type": "string"}
+        },
+        "securityDefinitions": {
+            "type": "object",
+            "patternProperties": {REGEX_SAFE_NAME: SCHEMA_SECURITY_SCHEME},
+            "additionalProperties": False
         }
     },
     "required": [
         "id",
         "title",
-        "security"
+        "security",
+        "securityDefinitions"
     ]
 }
 


### PR DESCRIPTION
I've made some small changes to make the thing description a bit more compliant with the current spec with regards to the `security` and `securityDefinitions` properties. I made these changes for my own application. Specifically so that the TD's would pass the the json schema validation in [wot-hive](https://github.com/oeg-upm/wot-hive). It is still missing `@context` info in that regard however, but I guess I could add that in fairly easily in another commit to this pull request. 

I saw that @JKRhb had made a similar attempt a year ago (after I had worked on it a bit), but got scared by all the tests failing and didn't want to look into it too much. 
On that note, I noticed there hadn't been much work aside from github action stuff since last year and was wondering if this repo was still under active development?