### PR TITLE
Update documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 wotpy is an implementation of a [W3C WoT Runtime](https://github.com/w3c/wot-architecture/blob/master/proposals/terminology.md#wot-runtime) and the [W3C WoT Scripting API](https://github.com/w3c/wot-architecture/blob/master/proposals/terminology.md#scripting-api) in Python.
 
-You can find the documentation at <https://eclipse-thingweb.github.io/wot-py/>.
+You can find the documentation at <https://eclipse-thingweb.github.io/wotpy/>.
 
 ### About the current version
 


### PR DESCRIPTION
BTW, the current version is `0.17.2` (see https://github.com/eclipse-thingweb/wotpy/tags) while the one shown on https://eclipse-thingweb.github.io/wotpy/ indicates `0.16.0`.
It seems we need to update the documentation. 